### PR TITLE
Add HACS links for easier install

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Vestaboard is a 6x22 characters connected split flap display for your home or of
 
 Add the repo in HACS:
 
-[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=AsteroidOrangeJuice&repository=vestaboard&category=integration)
+[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=DanielBaulig&repository=vestaboard&category=integration)
 
 Then install the **Vestaboard** integration from HACS. Set up the integration (you'll need your hostname/IP and API key):
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,23 @@ Vestaboard is a 6x22 characters connected split flap display for your home or of
 
 ## How do I use Vestaboard with Home Assistant?
 
-- Request a Vestaboard local API enablement token here: [Request Local API Enablement Token](https://www.vestaboard.com/local-api)
+### Setup
+
+1. Request a Vestaboard local API enablement token: [Request Local API Enablement Token](https://www.vestaboard.com/local-api)
+2. Validate you have the hostname or IP address of your Vestaboard
+
+### Recommended - Install via HACS
+
+Add the repo in HACS:
+
+[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=AsteroidOrangeJuice&repository=vestaboard&category=integration)
+
+Then install the **Vestaboard** integration from HACS. Set up the integration (you'll need your hostname/IP and API key):
+
+[![Open your Home Assistant instance and start setting up a new integration.](https://my.home-assistant.io/badges/config_flow_start.svg)](https://my.home-assistant.io/redirect/config_flow_start/?domain=vestaboard)
+
+### Manual installation
+
 - Install this custom integration code
 - Add a Vestaboard instance on your Integrations page (requiring host and local API key)
 - Use the vestaboard.post service to post to your Vestaboard

--- a/hacs.json
+++ b/hacs.json
@@ -1,0 +1,4 @@
+{
+  "name": "Vestaboard",
+  "render_readme": true
+}


### PR DESCRIPTION
This PR just updates the readme to make install easier by adding links for HACS so it's one click to add the repo and one click to install the integration.

Let me know if you need any testing or validation from me. I did manually validate this by pointing it at my fork and installing the integration that way.

Thanks for the integration!