### PR TITLE
Support Vestaboard Note, provide simple text-inputs for easy testing.

### DIFF
--- a/custom_components/vestaboard/__init__.py
+++ b/custom_components/vestaboard/__init__.py
@@ -257,7 +257,7 @@ async def async_setup_entry(hass, config):
 
     await hass.config_entries.async_forward_entry_setups(
         config,
-        ["sensor"],
+        ["sensor", "text"],
     )
 
     async def post(call):

--- a/custom_components/vestaboard/__init__.py
+++ b/custom_components/vestaboard/__init__.py
@@ -12,7 +12,7 @@ from homeassistant.helpers.update_coordinator import (
 
 _LOGGER=logging.getLogger(__name__)
 
-from .const import DOMAIN, CONF_LOCAL_API_HOST, CONF_LOCAL_API_KEY
+from .const import DOMAIN, CONF_LOCAL_API_HOST, CONF_LOCAL_API_KEY, MODEL_FLAGSHIP, MODEL_NOTE, MODEL_UNKNOWN
 
 ATTR_LINES="lines"
 
@@ -110,6 +110,11 @@ class Vestaboard:
     def __init__(self, host, local_api_key):
         self.host = host
         self.local_api_key = local_api_key
+        self.rows = None
+        self.columns = None
+        self.model = MODEL_UNKNOWN
+        self._character_map = character_map.copy()
+        self._inverted_character_map = inverted_character_map.copy()
 
     @property
     def auth_headers(self):
@@ -140,6 +145,32 @@ class Vestaboard:
         async with self.session() as session:
             yield await session.get(uri)
 
+    def _detect_model(self, message):
+        """Detect board model from message dimensions and update character maps."""
+        if self.rows is None or self.columns is None:
+            self.rows = len(message)
+            self.columns = len(message[0]) if message else 0
+            
+            # Detect model based on dimensions
+            if self.rows == 6 and self.columns == 22:
+                self.model = MODEL_FLAGSHIP
+                # Code 62 is degree symbol for Flagship
+                self._character_map['°'] = 62
+                self._inverted_character_map[62] = '°'
+                _LOGGER.info('Detected Vestaboard Flagship (6x22)')
+            elif self.rows == 3 and self.columns == 15:
+                self.model = MODEL_NOTE
+                # Code 62 is heart symbol for Note
+                self._character_map['♥'] = 62
+                self._inverted_character_map[62] = '♥'
+                # Remove degree symbol mapping for Note
+                if '°' in self._character_map:
+                    del self._character_map['°']
+                _LOGGER.info('Detected Vestaboard Note (3x15)')
+            else:
+                self.model = MODEL_UNKNOWN
+                _LOGGER.warning('Unknown Vestaboard model with dimensions %dx%d', self.rows, self.columns)
+
     async def read(self):
         async with self.get() as response:
             if response.status not in range(200, 299):
@@ -147,20 +178,28 @@ class Vestaboard:
                 return None
 
             json = await response.json(content_type="text/plain")
+            message = json['message']
+            
+            # Detect model on first read
+            self._detect_model(message)
 
-        return self.decode_lines(json['message'])
+        return self.decode_lines(message)
 
-    @staticmethod
-    def encode_lines(lines):
-        lines += [''] * (6 - len(lines))
-        normalized_lines = ['{:<22}'.format((line or '')[:22].upper()) for line in lines]
-        encoded_lines = [[character_map.get(char, 60) for char in line] for line in normalized_lines]
+    def encode_lines(self, lines):
+        """Encode lines using detected board dimensions."""
+        # Use detected dimensions, fallback to Flagship if not yet detected
+        rows = self.rows if self.rows is not None else 6
+        columns = self.columns if self.columns is not None else 22
+        
+        lines += [''] * (rows - len(lines))
+        normalized_lines = [f"{(line or '')[:columns].upper():<{columns}}" for line in lines[:rows]]
+        encoded_lines = [[self._character_map.get(char, 60) for char in line] for line in normalized_lines]
 
         return json.dumps(encoded_lines)
 
-    @staticmethod
-    def decode_lines(lines):
-        return [ ''.join([inverted_character_map.get(code, '?') for code in line]) for line in lines ]
+    def decode_lines(self, lines):
+        """Decode lines using detected character map."""
+        return [ ''.join([self._inverted_character_map.get(code, '?') for code in line]) for line in lines ]
 
     async def write(self, lines):
         async with self.post(self.encode_lines(lines)) as response:
@@ -176,6 +215,21 @@ class VestaboardCoordinator(DataUpdateCoordinator):
             update_interval=timedelta(seconds=30)
         )
         self.vestaboard = vestaboard
+
+    @property
+    def rows(self):
+        """Return the number of rows on the board."""
+        return self.vestaboard.rows if self.vestaboard.rows is not None else 6
+
+    @property
+    def columns(self):
+        """Return the number of columns on the board."""
+        return self.vestaboard.columns if self.vestaboard.columns is not None else 22
+
+    @property
+    def model(self):
+        """Return the detected model type."""
+        return self.vestaboard.model
 
     async def _async_update_data(self):
         async with async_timeout.timeout(10):

--- a/custom_components/vestaboard/const.py
+++ b/custom_components/vestaboard/const.py
@@ -2,3 +2,8 @@ DOMAIN="vestaboard"
 
 CONF_LOCAL_API_HOST="local_api_host"
 CONF_LOCAL_API_KEY="local_api_key"
+
+# Model types
+MODEL_FLAGSHIP="flagship"
+MODEL_NOTE="note"
+MODEL_UNKNOWN="unknown"

--- a/custom_components/vestaboard/sensor.py
+++ b/custom_components/vestaboard/sensor.py
@@ -24,6 +24,8 @@ class VestaboardLineEntity(CoordinatorEntity, SensorEntity):
 
 
 async def async_setup_entry(hass, config, async_add_entities):
+    coordinator = hass.data[DOMAIN][config.entry_id]['coordinator']
+    # Dynamically create sensors based on detected board dimensions
     async_add_entities(
-        [VestaboardLineEntity(hass.data[DOMAIN][config.entry_id]['coordinator'], line) for line in range(6)]
+        [VestaboardLineEntity(coordinator, line) for line in range(coordinator.rows)]
     )

--- a/custom_components/vestaboard/services.yaml
+++ b/custom_components/vestaboard/services.yaml
@@ -1,9 +1,9 @@
 post:
-  description: Posts a message to Vestaboard.
+  description: Posts a message to Vestaboard. Note: You can also use the individual text input entities for a simpler UI experience.
   fields:
     lines:
       name: Lines
-      description: The text to post. 6 lines with up to 22 characters each. You can use the special color characters \xc1 to \xc7.
+      description: The text to post as a list of lines. For Vestaboard Note (3x15), provide up to 3 lines with 15 characters each. For Vestaboard Flagship (6x22), provide up to 6 lines with 22 characters each. You can use the special color characters \xc1 to \xc7.
       required: true
       example: |
         - First line

--- a/custom_components/vestaboard/text.py
+++ b/custom_components/vestaboard/text.py
@@ -1,0 +1,62 @@
+from homeassistant.components.text import TextEntity
+from homeassistant.core import callback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+
+class VestaboardLineTextEntity(CoordinatorEntity, TextEntity):
+    """Text entity for editing a single Vestaboard line."""
+    
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator, line):
+        """Initialize the text entity."""
+        super().__init__(coordinator)
+        self.line = line
+        self._attr_unique_id = f"{coordinator.vestaboard.host}_line_{line}_text"
+        self._attr_native_max = coordinator.columns
+        self._attr_native_min = 0
+        self._attr_mode = "text"
+
+    @property
+    def name(self):
+        """Return the name of the entity."""
+        return f"Line {self.line}"
+
+    @property
+    def native_value(self):
+        """Return the current value."""
+        if self.coordinator.data and len(self.coordinator.data) > self.line:
+            # Return the current line content, stripped of trailing spaces
+            return self.coordinator.data[self.line].rstrip()
+        return ""
+
+    async def async_set_value(self, value: str) -> None:
+        """Set new text value and update the board."""
+        # Get current lines from coordinator
+        current_lines = list(self.coordinator.data) if self.coordinator.data else [''] * self.coordinator.rows
+        
+        # Update the specific line
+        current_lines[self.line] = value
+        
+        # Write to the board
+        result = await self.coordinator.vestaboard.write(current_lines)
+        
+        if result:
+            # Request a refresh to update all entities
+            await self.coordinator.async_request_refresh()
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self.async_write_ha_state()
+
+
+async def async_setup_entry(hass, config, async_add_entities):
+    """Set up Vestaboard text entities."""
+    coordinator = hass.data[DOMAIN][config.entry_id]['coordinator']
+    
+    # Create text entities for each line based on detected board dimensions
+    async_add_entities(
+        [VestaboardLineTextEntity(coordinator, line) for line in range(coordinator.rows)]
+    )


### PR DESCRIPTION
I have a Note, so modified this to dynamically read out how many rows and columns the configured board has.
To ease debugging, I included an entity to manually write text.